### PR TITLE
Fix: Resolve 401 errors in doc-and-style-r workflow

### DIFF
--- a/.github/workflows/doc-and-style-r.yml
+++ b/.github/workflows/doc-and-style-r.yml
@@ -50,13 +50,8 @@ jobs:
     name: doc and style
     runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.PAT }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      
-      - name: setup env using GITHUB_TOKEN, if no pat
-        if: env.GITHUB_PAT == ''
-        run: echo "GITHUB_PAT=${{ secrets.GITHUB_TOKEN}}" >> "$GITHUB_ENV"
-
       - name: checkout, make changes and submit as pr on new branch
         if: inputs.commit-directly == false
         uses: actions/checkout@v5


### PR DESCRIPTION
<!---
Thanks for opening a PR. This commented text will **NOT** appear in the final PR. Toggle between Write and Preview to see what your PR will look like without the comments.

The following individuals are available to review ghactions4r pull requests, so please select one of them as the reviewer and ask directly on the pull request (using `@mention`) if they are comfortable reviewing and provide a date you would like the review by.

 k-doering-NOAA Bai-Li-NOAA kellijohnson-NOAA Andrea-Havron-NOAA Schiano-NOAA msupernaw e-perl-NOAA ClaireGonzales-NOAA
-->

This PR fixes a failure in the doc-and-style-r workflow. {FIMS} failed at the `setup-r-dependencies` step with a `401 Unauthorized` error (see the failed GHA log [here](https://github.com/NOAA-FIMS/FIMS/actions/runs/19280014639/job/55186712230#step:10:214)). This was caused by the action hitting the GitHub API's anonymous rate limit when fetching R packages. 

The fix in this PR forces the workflow to use the job's `GITHUB_TOKEN` for the `GITHUB_PAT` environment variable. This ensures the `r-lib/actions/setup-r-dependencies` step is always authenticated with a valid token, avoiding anonymous API rate limits without needing a separate PAT. I have tested the new workflow in {FIMS}, and it successfully [passed](https://github.com/NOAA-FIMS/FIMS/actions/runs/19301804125) and created a new [PR](https://github.com/NOAA-FIMS/FIMS/pull/1029) with style suggestions.

